### PR TITLE
#87_global_header_removed

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,9 +24,9 @@ from models import database
 from views.orders import OrdersHandler, OrderHandler
 from views.items import ItemHandler, ItemsHandler
 from views.user import UsersHandler, UserHandler
+from views.pictures import ItemPictureHandler, PictureHandler
 
 from views.address import AddressesHandler, AddressHandler
-from views.pictures import PictureHandler, ItemPictureHandler
 
 app = Flask(__name__)
 CORS(app)

--- a/app.py
+++ b/app.py
@@ -21,12 +21,11 @@ from http.client import BAD_REQUEST
 from flask_cors import CORS
 
 from models import database
+from views.address import AddressesHandler, AddressHandler
 from views.orders import OrdersHandler, OrderHandler
 from views.items import ItemHandler, ItemsHandler
 from views.user import UsersHandler, UserHandler
 from views.pictures import ItemPictureHandler, PictureHandler
-
-from views.address import AddressesHandler, AddressHandler
 
 app = Flask(__name__)
 CORS(app)

--- a/app.py
+++ b/app.py
@@ -15,9 +15,8 @@ User can be deleted using `/api/users/<email>` and a list of all existing users
 can be retrieved making a GET to `/api/users/`
 """
 
-from flask import abort, Flask, request
+from flask import Flask
 from flask_restful import Api
-from http.client import BAD_REQUEST
 from flask_cors import CORS
 
 from models import database
@@ -30,26 +29,6 @@ from views.pictures import ItemPictureHandler, PictureHandler
 app = Flask(__name__)
 CORS(app)
 api = Api(app)
-
-
-@app.before_request
-def bad_content_type():
-    """Checks for a correct request"""
-
-    # In case of POST of a picture a "multipart/form-data" has to be specified
-    # in the content-type of the request header
-    if request.endpoint == 'itempicturehandler' and request.method == 'POST':
-        ct = dict(request.headers).get('Content-Type', '')
-        if "multipart/form-data" not in ct:
-            abort(BAD_REQUEST)
-    # Force POST and PUT methods to have `Content-Type` as 'application/json'
-    # before proceeding inside the method handlers, that use `request.get_json`
-    # from `flask.request` that require the header to be set in order to return
-    # the content of the request.
-    elif request.method in ('POST', 'PUT'):
-        ct = dict(request.headers).get('Content-Type', '')
-        if ct != 'application/json':
-            abort(BAD_REQUEST)
 
 
 @app.before_request

--- a/models.py
+++ b/models.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 from exceptions import InsufficientAvailabilityException
 from utils import remove_image
 
+
 database = SqliteDatabase('database.db')
 
 

--- a/tests/test_addresses.py
+++ b/tests/test_addresses.py
@@ -67,8 +67,7 @@ class TestAddresses(TestCase):
         resp = open_with_auth(self.app, '/addresses/',
                               'GET', user.email, TEST_USER_PSW, None, None)
         assert resp.status_code == OK
-        assert json.loads(resp.data) == [addr.json(),
-                                         addr1.json()]
+        assert json.loads(resp.data) == [addr.json(), addr1.json()]
 
     def test_create_address__success(self):
         user = add_user('mariorossi@gmail.com', '123')

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -91,6 +91,12 @@ class TestItems(TestCase):
         except ValueError:
             assert False
 
+    def test_post_item__not_json_failure(self):
+        resp = self.app.post('/items/', data=test_utils.wrong_dump(TEST_ITEM),
+                             content_type='application/json')
+        assert resp.status_code == client.BAD_REQUEST
+        assert len(Item.select()) == 0
+
     def test_post_item__failed(self):
         resp = self.app.post('/items/', data=json.dumps(TEST_ITEM_WRONG),
                              content_type='application/json')

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -3,7 +3,7 @@ Test suite for User(s) resources.
 """
 
 from models import User, Address, Item, Order
-from tests.test_utils import open_with_auth, add_user, add_address
+from tests.test_utils import open_with_auth, add_user, add_address, wrong_dump
 from tests.test_case import TestCase
 from http.client import (OK, NOT_FOUND, NO_CONTENT, BAD_REQUEST,
                          CREATED, CONFLICT, UNAUTHORIZED)
@@ -62,7 +62,7 @@ class TestUser(TestCase):
         for user in User.select():
             assert user.admin is False
 
-    def test_post_new_user_no_json__fail(self):
+    def test_post_new_user__not_json_failure(self):
         user = {
             'first_name': 'Mario',
             'last_name': 'Rossi',
@@ -70,9 +70,11 @@ class TestUser(TestCase):
             'password': 'aksdg',
         }
         resp = self.app.post(API_ENDPOINT.format('users/'),
-                             data=json.dumps(user))
+                             data=wrong_dump(user),
+                             content_type='application/json')
 
         assert resp.status_code == BAD_REQUEST
+        assert User.select().count() == 0
 
     def test_post_new_user_email_exists__fail(self):
         add_user('mail@gmail.com', TEST_USER_PSW)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,12 +8,12 @@ import shutil
 from utils import get_image_folder
 
 
-def wrong_dump(d):
+def wrong_dump(data):
     """
     Give a wrong encoding (urlencode-like) to the given dictionary
     """
     return reduce(lambda x, y: "{}&{}".format(x, y), [
-        "{}={}".format(k, v) for k, v in zip(d.keys(), d.values())])
+        "{}={}".format(k, v) for k, v in zip(data.keys(), data.values())])
 
 
 def add_user(email, psw):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+from functools import reduce
 from models import Address, User
 from base64 import b64encode
 import uuid
@@ -5,6 +6,14 @@ import os
 import random
 import shutil
 from utils import get_image_folder
+
+
+def wrong_dump(d):
+    """
+    Give a wrong encoding (urlencode-like) to the given dictionary
+    """
+    return reduce(lambda x, y: "{}&{}".format(x, y), [
+        "{}={}".format(k, v) for k, v in zip(d.keys(), d.values())])
 
 
 def add_user(email, psw):

--- a/views/address.py
+++ b/views/address.py
@@ -25,7 +25,7 @@ class AddressesHandler(Resource):
     @auth.login_required
     def post(self):
         user = g.user
-        res = request.get_json()
+        res = request.get_json(force=True)
 
         check_required_fields(
             request_data=res,
@@ -50,7 +50,9 @@ class AddressHandler(Resource):
         user = g.user
 
         try:
-            return Address.get(Address.user == user, Address.address_id == address_id).json(), OK
+            return Address.get(
+                Address.user == user,
+                Address.address_id == address_id).json(), OK
         except Address.DoesNotExist:
             return None, NOT_FOUND
 
@@ -63,7 +65,7 @@ class AddressHandler(Resource):
         except Address.DoesNotExist:
             return None, NOT_FOUND
 
-        res = request.get_json()
+        res = request.get_json(force=True)
 
         country = res.get('country')
         city = res.get('city')

--- a/views/address.py
+++ b/views/address.py
@@ -50,9 +50,7 @@ class AddressHandler(Resource):
         user = g.user
 
         try:
-            return Address.get(
-                Address.user == user,
-                Address.address_id == address_id).json(), OK
+            return Address.get(Address.user == user, Address.address_id == address_id).json(), OK
         except Address.DoesNotExist:
             return None, NOT_FOUND
 

--- a/views/items.py
+++ b/views/items.py
@@ -25,7 +25,7 @@ class ItemsHandler(Resource):
         Insert a new item, the item_id identifier is forwarded
         from the one generated from the database
         """
-        request_data = request.get_json()
+        request_data = request.get_json(force=True)
         check_required_fields(
             request_data=request_data,
             required_fields=['name', 'price', 'description', 'availability'])
@@ -61,7 +61,7 @@ class ItemHandler(Resource):
         except Item.DoesNotExist:
             return None, client.NOT_FOUND
 
-        request_data = request.get_json()
+        request_data = request.get_json(force=True)
         name = request_data.get('name')
         price = request_data.get('price')
         description = request_data.get('description')

--- a/views/orders.py
+++ b/views/orders.py
@@ -27,7 +27,7 @@ class OrdersHandler(Resource):
     def post(self):
         """ Insert a new order."""
         user = g.user
-        res = request.get_json()
+        res = request.get_json(force=True)
         # Check that the order has an 'items' and 'delivery_address' attributes
         # otherwise it's useless to continue.
         for key in ('items', 'delivery_address'):
@@ -83,7 +83,7 @@ class OrderHandler(Resource):
     @auth.login_required
     def patch(self, order_id):
         """ Modify a specific order. """
-        res = request.get_json()
+        res = request.get_json(force=True)
 
         res_items = res['order'].get('items')
         res_address = res['order'].get('delivery_address')

--- a/views/pictures.py
+++ b/views/pictures.py
@@ -1,13 +1,13 @@
 import os
-import uuid
-
-from models import Item
-from models import Picture
 import utils
+import uuid
 
 from flask import request, send_from_directory
 from flask_restful import Resource
 import http.client as client
+
+from models import Item
+from models import Picture
 
 ALLOWED_EXTENSION = ['jpg', 'jpeg', 'png', 'gif']
 
@@ -56,7 +56,6 @@ class PictureHandler(Resource):
 
     def get(self, picture_id):
         """Retrieve the picture specified by picture_id"""
-
         try:
             picture = Picture.get(Picture.picture_id == picture_id)
         except Picture.DoesNotExist:

--- a/views/user.py
+++ b/views/user.py
@@ -27,7 +27,7 @@ class UsersHandler(Resource):
         # request and not be empty strings.
         required_fields = ['first_name', 'last_name', 'email', 'password']
 
-        request_data = request.get_json()
+        request_data = request.get_json(force=True)
 
         # For every field required for creating a new user try to get the
         # value from the json data of the request.


### PR DESCRIPTION
Since the global header check on the parameters encoding needed to know the identity of the requested endpoint, the logic has become coupled to the rest of the code. For this reason I moved the check back to the single requests, using get_json(force=True) for json requests. I also added tests to check that with a non json encoding the answer has to be BAD_REQUEST.