### PR TITLE
validation function for tests with jsonapi

### DIFF
--- a/tests/test_addresses.py
+++ b/tests/test_addresses.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from models import Address
 from tests.test_case import TestCase
-from tests.test_utils import (add_address, add_user, RESULTS, validate_response,
+from tests.test_utils import (add_address, add_user, RESULTS, assert_valid_response,
                               open_with_auth, format_jsonapi_request, wrong_dump)
 
 TEST_USER_PSW = '123'
@@ -64,7 +64,7 @@ class TestAddresses(TestCase):
         assert resp.status_code == OK
 
         expected_result = EXPECTED_RESULTS['get_addresses__success']
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
     def test_create_address__success(self):
         user = add_user('mariorossi@gmail.com', '123',
@@ -79,7 +79,7 @@ class TestAddresses(TestCase):
         assert len(Address.select()) == 1
 
         expected_result = EXPECTED_RESULTS['create_address__success']
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
     def test_create_address__failure_missing_field(self):
         user = add_user('mariorossi@gmail.com', '123')
@@ -94,7 +94,7 @@ class TestAddresses(TestCase):
         assert resp.status_code == BAD_REQUEST
         assert len(Address.select()) == 0
         expected_result = EXPECTED_RESULTS['create_address__failure_missing_field']
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
     def test_create_address__failure_empty_field(self):
         user = add_user('mariorossi@gmail.com', '123')
@@ -109,7 +109,7 @@ class TestAddresses(TestCase):
         assert resp.status_code == BAD_REQUEST
         assert len(Address.select()) == 0
         expected_result = EXPECTED_RESULTS['create_address__failure_empty_field']
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
     def test_get_address(self):
         user = add_user('mariorossi@gmail.com', '123',
@@ -122,7 +122,7 @@ class TestAddresses(TestCase):
                               user.email, TEST_USER_PSW, None, None)
 
         assert resp.status_code == OK
-        assert validate_response(resp.data, EXPECTED_RESULTS['get_address'])
+        assert_valid_response(resp.data, EXPECTED_RESULTS['get_address'])
 
     def test_get_address__failed(self):
         user = add_user('mariorossi@gmail.com', '123')
@@ -152,7 +152,7 @@ class TestAddresses(TestCase):
         expected_result = EXPECTED_RESULTS['put_address__success']
         # Check that the response data is what is expected and is also
         # the same as what has ben actually saved
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
         assert expected_result == json.loads(upd_addr)
 
     def test_patch_address__wrong_uuid(self):

--- a/tests/test_addresses.py
+++ b/tests/test_addresses.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from models import Address
 from tests.test_case import TestCase
-from tests.test_utils import (add_address, add_user, RESULTS,
+from tests.test_utils import (add_address, add_user, RESULTS, validate_response,
                               open_with_auth, format_jsonapi_request, wrong_dump)
 
 TEST_USER_PSW = '123'
@@ -64,7 +64,7 @@ class TestAddresses(TestCase):
         assert resp.status_code == OK
 
         expected_result = EXPECTED_RESULTS['get_addresses__success']
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
 
     def test_create_address__success(self):
         user = add_user('mariorossi@gmail.com', '123',
@@ -79,7 +79,7 @@ class TestAddresses(TestCase):
         assert len(Address.select()) == 1
 
         expected_result = EXPECTED_RESULTS['create_address__success']
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
 
     def test_create_address__failure_missing_field(self):
         user = add_user('mariorossi@gmail.com', '123')
@@ -94,7 +94,7 @@ class TestAddresses(TestCase):
         assert resp.status_code == BAD_REQUEST
         assert len(Address.select()) == 0
         expected_result = EXPECTED_RESULTS['create_address__failure_missing_field']
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
 
     def test_create_address__failure_empty_field(self):
         user = add_user('mariorossi@gmail.com', '123')
@@ -109,7 +109,7 @@ class TestAddresses(TestCase):
         assert resp.status_code == BAD_REQUEST
         assert len(Address.select()) == 0
         expected_result = EXPECTED_RESULTS['create_address__failure_empty_field']
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
 
     def test_get_address(self):
         user = add_user('mariorossi@gmail.com', '123',
@@ -122,7 +122,7 @@ class TestAddresses(TestCase):
                               user.email, TEST_USER_PSW, None, None)
 
         assert resp.status_code == OK
-        assert json.loads(resp.data) == EXPECTED_RESULTS['get_address']
+        assert validate_response(resp.data, EXPECTED_RESULTS['get_address'])
 
     def test_get_address__failed(self):
         user = add_user('mariorossi@gmail.com', '123')
@@ -152,7 +152,8 @@ class TestAddresses(TestCase):
         expected_result = EXPECTED_RESULTS['put_address__success']
         # Check that the response data is what is expected and is also
         # the same as what has ben actually saved
-        assert json.loads(resp.data) == expected_result == json.loads(upd_addr)
+        assert validate_response(resp.data, expected_result)
+        assert expected_result == json.loads(upd_addr)
 
     def test_patch_address__wrong_uuid(self):
         user = add_user('mariorossi@gmail.com', '123')

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -12,7 +12,7 @@ import utils
 
 from models import Item, Picture
 from tests import test_utils
-from tests.test_utils import format_jsonapi_request, RESULTS, validate_response
+from tests.test_utils import format_jsonapi_request, RESULTS, assert_valid_response
 
 TEST_IMAGE_FOLDER = 'test_images'
 
@@ -88,7 +88,7 @@ class TestItems(TestCase):
         assert len(Item.select()) == 1
 
         expected_result = EXPECTED_RESULTS['post_item__success']
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
     def test_post_item__not_json_failure(self):
         resp = self.app.post('/items/', data=test_utils.wrong_dump(TEST_ITEM),
@@ -111,7 +111,7 @@ class TestItems(TestCase):
         assert resp.status_code == client.CREATED
 
         expected_result = EXPECTED_RESULTS['post_item__round_price']
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
         item = Item.select()[0]
         assert round(TEST_ITEM_PRECISION['price'], 5) == float(item.price)
@@ -135,7 +135,7 @@ class TestItems(TestCase):
 
         assert resp.status_code == client.BAD_REQUEST
         expected_result = EXPECTED_RESULTS['post_item_missing_field__fail']
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
     def test_get_items__success(self):
         Item.create(**TEST_ITEM)
@@ -144,14 +144,14 @@ class TestItems(TestCase):
         resp = self.app.get('/items/')
 
         assert resp.status_code == client.OK
-        assert validate_response(resp.data, EXPECTED_RESULTS['get_items__success'])
+        assert_valid_response(resp.data, EXPECTED_RESULTS['get_items__success'])
 
     def test_get_item__success(self):
         item = Item.create(**TEST_ITEM)
         resp = self.app.get('/items/{item_uuid}'.format(item_uuid=item.uuid))
 
         assert resp.status_code == client.OK
-        assert validate_response(resp.data, EXPECTED_RESULTS['get_item__success'])
+        assert_valid_response(resp.data, EXPECTED_RESULTS['get_item__success'])
 
     def test_get_item__failed(self):
         resp = self.app.get('/items/{item_uuid}'.format(item_uuid=WRONG_UUID))
@@ -167,7 +167,7 @@ class TestItems(TestCase):
 
         assert resp.status_code == client.OK
         expected_result = EXPECTED_RESULTS['patch_change1item__success']
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
         assert Item.get().name == 'new-name'
 
@@ -185,7 +185,7 @@ class TestItems(TestCase):
 
         assert resp.status_code == client.OK
         expected_result = EXPECTED_RESULTS['patch_allitems__success']
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
         # validate patch functionality checking for updated values
         item = Item.get()

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -12,7 +12,7 @@ import utils
 
 from models import Item, Picture
 from tests import test_utils
-from tests.test_utils import format_jsonapi_request, RESULTS
+from tests.test_utils import format_jsonapi_request, RESULTS, validate_response
 
 TEST_IMAGE_FOLDER = 'test_images'
 
@@ -88,7 +88,7 @@ class TestItems(TestCase):
         assert len(Item.select()) == 1
 
         expected_result = EXPECTED_RESULTS['post_item__success']
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
 
     def test_post_item__not_json_failure(self):
         resp = self.app.post('/items/', data=test_utils.wrong_dump(TEST_ITEM),
@@ -111,7 +111,7 @@ class TestItems(TestCase):
         assert resp.status_code == client.CREATED
 
         expected_result = EXPECTED_RESULTS['post_item__round_price']
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
 
         item = Item.select()[0]
         assert round(TEST_ITEM_PRECISION['price'], 5) == float(item.price)
@@ -135,7 +135,7 @@ class TestItems(TestCase):
 
         assert resp.status_code == client.BAD_REQUEST
         expected_result = EXPECTED_RESULTS['post_item_missing_field__fail']
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
 
     def test_get_items__success(self):
         Item.create(**TEST_ITEM)
@@ -144,14 +144,14 @@ class TestItems(TestCase):
         resp = self.app.get('/items/')
 
         assert resp.status_code == client.OK
-        assert json.loads(resp.data) == EXPECTED_RESULTS['get_items__success']
+        assert validate_response(resp.data, EXPECTED_RESULTS['get_items__success'])
 
     def test_get_item__success(self):
         item = Item.create(**TEST_ITEM)
         resp = self.app.get('/items/{item_uuid}'.format(item_uuid=item.uuid))
 
         assert resp.status_code == client.OK
-        assert json.loads(resp.data) == EXPECTED_RESULTS['get_item__success']
+        assert validate_response(resp.data, EXPECTED_RESULTS['get_item__success'])
 
     def test_get_item__failed(self):
         resp = self.app.get('/items/{item_uuid}'.format(item_uuid=WRONG_UUID))
@@ -167,7 +167,7 @@ class TestItems(TestCase):
 
         assert resp.status_code == client.OK
         expected_result = EXPECTED_RESULTS['patch_change1item__success']
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
 
         assert Item.get().name == 'new-name'
 
@@ -185,7 +185,7 @@ class TestItems(TestCase):
 
         assert resp.status_code == client.OK
         expected_result = EXPECTED_RESULTS['patch_allitems__success']
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
 
         # validate patch functionality checking for updated values
         item = Item.get()

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -13,7 +13,7 @@ from models import Item, Order, OrderItem, WrongQuantity
 from tests.test_case import TestCase
 from tests.test_utils import (RESULTS, add_address, add_admin_user, add_user,
                               format_jsonapi_request, open_with_auth,
-                              wrong_dump)
+                              validate_response, wrong_dump)
 
 # main endpoint for API
 API_ENDPOINT = '/{}'
@@ -57,7 +57,7 @@ class TestOrders(TestCase):
         expected_result = EXPECTED_RESULTS['get_orders__success']
 
         assert resp.status_code == OK
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
 
     def test_get_order__non_existing_empty_orders(self):
         resp = self.app.get('/orders/{}'.format(uuid4()))
@@ -108,7 +108,7 @@ class TestOrders(TestCase):
 
         expected_result = EXPECTED_RESULTS['get_order__success']
         assert resp.status_code == OK
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
 
     def test_create_order__success(self):
         Item.create(
@@ -161,8 +161,7 @@ class TestOrders(TestCase):
         assert len(OrderItem.select()) == 2
         order = Order.get()
         expected_result = EXPECTED_RESULTS['create_order__success']
-        # inject the order id
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
 
     def test_create_order__not_json_failure(self):
         Item.create(
@@ -278,7 +277,7 @@ class TestOrders(TestCase):
                               json.dumps(data))
         assert resp.status_code == BAD_REQUEST
         expected_result = EXPECTED_RESULTS['create_order__failure_missing_field']
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
         assert len(Order.select()) == 0
 
     def test_create_order__non_existing_address(self):
@@ -505,7 +504,7 @@ class TestOrders(TestCase):
         order = Order.get()
         expected_result = EXPECTED_RESULTS['update_order__new_item']
 
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
 
     def test_update_order__item_quantity_zero(self):
         item1 = Item.create(
@@ -549,7 +548,7 @@ class TestOrders(TestCase):
 
         expected_result = EXPECTED_RESULTS['update_order__item_quantity_zero']
 
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
 
         # test remove with quantity=0 functionality, item1 is not present.
         assert len(order.order_items) == 1
@@ -601,7 +600,7 @@ class TestOrders(TestCase):
 
         expected_result = EXPECTED_RESULTS['update_order__remove_item_without_delete']
 
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
         assert len(order.order_items) == 1
         assert order.order_items[0].quantity == 20
 
@@ -646,7 +645,7 @@ class TestOrders(TestCase):
 
         expected_result = EXPECTED_RESULTS['update_order__add_item']
 
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
 
     def test_update_order__success(self):
         item1 = Item.create(
@@ -703,7 +702,7 @@ class TestOrders(TestCase):
         expected_result = EXPECTED_RESULTS['update_order__success']
 
         assert resp.status_code == OK
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
 
     def test_update_order__non_existing_items(self):
         item1 = Item.create(
@@ -845,7 +844,7 @@ class TestOrders(TestCase):
         assert resp.status_code == OK
 
         expected_result = EXPECTED_RESULTS['update_order__success_admin_not_owner']
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
 
     def test_update_order_empty_items_list__fail(self):
         item1 = Item.create(

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -13,7 +13,7 @@ from models import Item, Order, OrderItem, WrongQuantity
 from tests.test_case import TestCase
 from tests.test_utils import (RESULTS, add_address, add_admin_user, add_user,
                               format_jsonapi_request, open_with_auth,
-                              validate_response, wrong_dump)
+                              assert_valid_response, wrong_dump)
 
 # main endpoint for API
 API_ENDPOINT = '/{}'
@@ -57,7 +57,7 @@ class TestOrders(TestCase):
         expected_result = EXPECTED_RESULTS['get_orders__success']
 
         assert resp.status_code == OK
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
     def test_get_order__non_existing_empty_orders(self):
         resp = self.app.get('/orders/{}'.format(uuid4()))
@@ -108,7 +108,7 @@ class TestOrders(TestCase):
 
         expected_result = EXPECTED_RESULTS['get_order__success']
         assert resp.status_code == OK
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
     def test_create_order__success(self):
         Item.create(
@@ -161,7 +161,7 @@ class TestOrders(TestCase):
         assert len(OrderItem.select()) == 2
         order = Order.get()
         expected_result = EXPECTED_RESULTS['create_order__success']
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
     def test_create_order__not_json_failure(self):
         Item.create(
@@ -277,7 +277,7 @@ class TestOrders(TestCase):
                               json.dumps(data))
         assert resp.status_code == BAD_REQUEST
         expected_result = EXPECTED_RESULTS['create_order__failure_missing_field']
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
         assert len(Order.select()) == 0
 
     def test_create_order__non_existing_address(self):
@@ -504,7 +504,7 @@ class TestOrders(TestCase):
         order = Order.get()
         expected_result = EXPECTED_RESULTS['update_order__new_item']
 
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
     def test_update_order__item_quantity_zero(self):
         item1 = Item.create(
@@ -548,7 +548,7 @@ class TestOrders(TestCase):
 
         expected_result = EXPECTED_RESULTS['update_order__item_quantity_zero']
 
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
         # test remove with quantity=0 functionality, item1 is not present.
         assert len(order.order_items) == 1
@@ -600,7 +600,7 @@ class TestOrders(TestCase):
 
         expected_result = EXPECTED_RESULTS['update_order__remove_item_without_delete']
 
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
         assert len(order.order_items) == 1
         assert order.order_items[0].quantity == 20
 
@@ -645,7 +645,7 @@ class TestOrders(TestCase):
 
         expected_result = EXPECTED_RESULTS['update_order__add_item']
 
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
     def test_update_order__success(self):
         item1 = Item.create(
@@ -702,7 +702,7 @@ class TestOrders(TestCase):
         expected_result = EXPECTED_RESULTS['update_order__success']
 
         assert resp.status_code == OK
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
     def test_update_order__non_existing_items(self):
         item1 = Item.create(
@@ -844,7 +844,7 @@ class TestOrders(TestCase):
         assert resp.status_code == OK
 
         expected_result = EXPECTED_RESULTS['update_order__success_admin_not_owner']
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
     def test_update_order_empty_items_list__fail(self):
         item1 = Item.create(

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from models import Item, Order, Address
 from schemas import OrderSchema, UserSchema, AddressSchema, ItemSchema
 from tests.test_utils import (add_address, add_user, format_jsonapi_request,
-                              RESULTS, validate_response)
+                              RESULTS, assert_valid_response)
 
 USER_TEST_DICT = {
     "first_name": "Monty",
@@ -65,7 +65,7 @@ class TestUserSchema(TestCase):
 
         assert type(parsed_user) is str
 
-        assert validate_response(parsed_user, expected_result)
+        assert_valid_response(parsed_user, expected_result)
         assert errors == {}
 
     def test_get_users_list_json__success(self):
@@ -73,14 +73,14 @@ class TestUserSchema(TestCase):
 
         assert type(parsed) is str
         expected_result = EXPECTED_USERS['get_users_list_json__success']
-        assert validate_response(parsed, expected_result)
+        assert_valid_response(parsed, expected_result)
 
     def test_user_include_orders__success(self):
         parsed_user, _ = UserSchema.jsonapi(
             self.user1, include_data=['orders'])
 
         expected_result = EXPECTED_USERS['user_include_orders__success']
-        assert validate_response(parsed_user, expected_result)
+        assert_valid_response(parsed_user, expected_result)
 
     def test_user_validate_input__success(self):
         post_data = format_jsonapi_request('user', USER_TEST_DICT)
@@ -99,7 +99,7 @@ class TestUserSchema(TestCase):
         errors = UserSchema.validate_input(post_data)
 
         expected_result = EXPECTED_USERS['user_validate_input__fail']
-        assert validate_response(errors, expected_result)
+        assert_valid_response(errors, expected_result)
 
 
 class TestOrderSchema(TestCase):
@@ -140,7 +140,7 @@ class TestOrderSchema(TestCase):
         assert type(parsed) == str
 
         expected_result = EXPECTED_ORDERS['order_json__success']
-        assert validate_response(parsed, expected_result)
+        assert_valid_response(parsed, expected_result)
 
     def test_order_validate_input__success(self):
         data = {
@@ -188,7 +188,7 @@ class TestOrderSchema(TestCase):
         assert type(parsed) is str
 
         expected_result = EXPECTED_ORDERS['get_orders_list__success']
-        assert validate_response(parsed, expected_result)
+        assert_valid_response(parsed, expected_result)
 
     def test_order_validate_fields__fail(self):
         order = {
@@ -206,7 +206,7 @@ class TestOrderSchema(TestCase):
         errors = OrderSchema.validate_input(post_data)
 
         expected_result = EXPECTED_ORDERS['order_validate_fields__fail']
-        assert validate_response(errors, expected_result)
+        assert_valid_response(errors, expected_result)
 
 
 class TestAddressSchema(TestCase):
@@ -242,7 +242,7 @@ class TestAddressSchema(TestCase):
         errors = AddressSchema.validate_input(post_data)
 
         expected_result = EXPECTED_ADDRESSES['address_validate_input__fail']
-        assert validate_response(errors, expected_result)
+        assert_valid_response(errors, expected_result)
 
     def test_get_address_json__success(self):
 
@@ -252,7 +252,7 @@ class TestAddressSchema(TestCase):
         assert type(data) is str
 
         expected_result = EXPECTED_ADDRESSES['get_address_json__success']
-        assert validate_response(data, expected_result)
+        assert_valid_response(data, expected_result)
 
     def test_address_json_include_user__success(self):
         data, errors = AddressSchema.jsonapi(self.addr, include_data=['user'])
@@ -261,7 +261,7 @@ class TestAddressSchema(TestCase):
         assert type(data) is str
 
         expected_result = EXPECTED_ADDRESSES['get_address_json_include_user__success']
-        assert validate_response(data, expected_result)
+        assert_valid_response(data, expected_result)
 
     def test_get_addresses_list__success(self):
         add_address(
@@ -271,7 +271,7 @@ class TestAddressSchema(TestCase):
         data = AddressSchema.jsonapi_list(addr_list)
 
         expected_result = EXPECTED_ADDRESSES['get_addresses_list__success']
-        assert validate_response(data, expected_result)
+        assert_valid_response(data, expected_result)
 
 
 class TestItemSchema(TestCase):
@@ -315,17 +315,17 @@ class TestItemSchema(TestCase):
         errors = ItemSchema.validate_input(post_data)
 
         expected_result = EXPECTED_ITEMS['item_validate_input__fail']
-        assert validate_response(errors, expected_result)
+        assert_valid_response(errors, expected_result)
 
     def test_get_item_json__success(self):
         data, errors = ItemSchema.jsonapi(self.item1)
 
         assert errors == {}
         expected_result = EXPECTED_ITEMS['get_item_json__success']
-        assert validate_response(data, expected_result)
+        assert_valid_response(data, expected_result)
 
     def test_get_items_list__success(self):
         data = ItemSchema.jsonapi_list([self.item1, self.item2])
 
         expected_result = EXPECTED_ITEMS['get_items_list__success']
-        assert validate_response(data, expected_result)
+        assert_valid_response(data, expected_result)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -10,8 +10,6 @@ import copy
 
 from datetime import datetime
 
-import simplejson as json
-
 from models import Item, Order, Address
 from schemas import OrderSchema, UserSchema, AddressSchema, ItemSchema
 from tests.test_utils import (add_address, add_user, format_jsonapi_request,

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -14,10 +14,8 @@ import simplejson as json
 
 from models import Item, Order, Address
 from schemas import OrderSchema, UserSchema, AddressSchema, ItemSchema
-from tests.test_utils import _test_res_sort_included as sort_included
-from tests.test_utils import _test_res_sort_errors as sort_errors
 from tests.test_utils import (add_address, add_user, format_jsonapi_request,
-                              RESULTS)
+                              RESULTS, validate_response)
 
 USER_TEST_DICT = {
     "first_name": "Monty",
@@ -69,7 +67,7 @@ class TestUserSchema(TestCase):
 
         assert type(parsed_user) is str
 
-        assert json.loads(parsed_user) == expected_result
+        assert validate_response(parsed_user, expected_result)
         assert errors == {}
 
     def test_get_users_list_json__success(self):
@@ -77,14 +75,14 @@ class TestUserSchema(TestCase):
 
         assert type(parsed) is str
         expected_result = EXPECTED_USERS['get_users_list_json__success']
-        assert json.loads(parsed) == expected_result
+        assert validate_response(parsed, expected_result)
 
     def test_user_include_orders__success(self):
         parsed_user, _ = UserSchema.jsonapi(
             self.user1, include_data=['orders'])
 
         expected_result = EXPECTED_USERS['user_include_orders__success']
-        assert json.loads(parsed_user) == expected_result
+        assert validate_response(parsed_user, expected_result)
 
     def test_user_validate_input__success(self):
         post_data = format_jsonapi_request('user', USER_TEST_DICT)
@@ -103,7 +101,7 @@ class TestUserSchema(TestCase):
         errors = UserSchema.validate_input(post_data)
 
         expected_result = EXPECTED_USERS['user_validate_input__fail']
-        assert sort_errors(errors) == expected_result
+        assert validate_response(errors, expected_result)
 
 
 class TestOrderSchema(TestCase):
@@ -144,8 +142,7 @@ class TestOrderSchema(TestCase):
         assert type(parsed) == str
 
         expected_result = EXPECTED_ORDERS['order_json__success']
-        parsed = sort_included(json.loads(parsed))
-        assert parsed == expected_result
+        assert validate_response(parsed, expected_result)
 
     def test_order_validate_input__success(self):
         data = {
@@ -193,7 +190,7 @@ class TestOrderSchema(TestCase):
         assert type(parsed) is str
 
         expected_result = EXPECTED_ORDERS['get_orders_list__success']
-        assert json.loads(parsed) == expected_result
+        assert validate_response(parsed, expected_result)
 
     def test_order_validate_fields__fail(self):
         order = {
@@ -211,7 +208,7 @@ class TestOrderSchema(TestCase):
         errors = OrderSchema.validate_input(post_data)
 
         expected_result = EXPECTED_ORDERS['order_validate_fields__fail']
-        assert sort_errors(errors) == expected_result
+        assert validate_response(errors, expected_result)
 
 
 class TestAddressSchema(TestCase):
@@ -247,7 +244,7 @@ class TestAddressSchema(TestCase):
         errors = AddressSchema.validate_input(post_data)
 
         expected_result = EXPECTED_ADDRESSES['address_validate_input__fail']
-        assert sort_errors(errors) == expected_result
+        assert validate_response(errors, expected_result)
 
     def test_get_address_json__success(self):
 
@@ -257,7 +254,7 @@ class TestAddressSchema(TestCase):
         assert type(data) is str
 
         expected_result = EXPECTED_ADDRESSES['get_address_json__success']
-        assert json.loads(data) == expected_result
+        assert validate_response(data, expected_result)
 
     def test_address_json_include_user__success(self):
         data, errors = AddressSchema.jsonapi(self.addr, include_data=['user'])
@@ -266,7 +263,7 @@ class TestAddressSchema(TestCase):
         assert type(data) is str
 
         expected_result = EXPECTED_ADDRESSES['get_address_json_include_user__success']
-        assert json.loads(data) == expected_result
+        assert validate_response(data, expected_result)
 
     def test_get_addresses_list__success(self):
         add_address(
@@ -276,7 +273,7 @@ class TestAddressSchema(TestCase):
         data = AddressSchema.jsonapi_list(addr_list)
 
         expected_result = EXPECTED_ADDRESSES['get_addresses_list__success']
-        assert json.loads(data) == expected_result
+        assert validate_response(data, expected_result)
 
 
 class TestItemSchema(TestCase):
@@ -320,17 +317,17 @@ class TestItemSchema(TestCase):
         errors = ItemSchema.validate_input(post_data)
 
         expected_result = EXPECTED_ITEMS['item_validate_input__fail']
-        assert sort_errors(errors) == expected_result
+        assert validate_response(errors, expected_result)
 
     def test_get_item_json__success(self):
         data, errors = ItemSchema.jsonapi(self.item1)
 
         assert errors == {}
         expected_result = EXPECTED_ITEMS['get_item_json__success']
-        assert json.loads(data) == expected_result
+        assert validate_response(data, expected_result)
 
     def test_get_items_list__success(self):
         data = ItemSchema.jsonapi_list([self.item1, self.item2])
 
         expected_result = EXPECTED_ITEMS['get_items_list__success']
-        assert json.loads(data) == expected_result
+        assert validate_response(data, expected_result)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,15 +1,16 @@
 """
 Test suite for User(s) resources.
 """
-from models import User, Address, Item, Order
-from tests.test_utils import (add_address, add_user, add_admin_user, format_jsonapi_request,
-                              RESULTS, open_with_auth, wrong_dump)
-from tests.test_case import TestCase
-
 import json
 import uuid
 from http.client import (BAD_REQUEST, CONFLICT, CREATED, NO_CONTENT, NOT_FOUND,
                          OK, UNAUTHORIZED)
+
+from models import Address, Item, Order, User
+from tests.test_case import TestCase
+from tests.test_utils import (RESULTS, add_address, add_admin_user, add_user,
+                              format_jsonapi_request, open_with_auth,
+                              validate_response, wrong_dump)
 
 # main endpoint for API
 API_ENDPOINT = '/{}'
@@ -36,7 +37,7 @@ class TestUser(TestCase):
 
         assert resp.status_code == OK
         expected_result = EXPECTED_RESULTS['get_users_list__success']
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
 
     def test_post_new_user__success(self):
         user = format_jsonapi_request('user', {
@@ -50,11 +51,9 @@ class TestUser(TestCase):
                              content_type='application/json')
 
         assert resp.status_code == CREATED
-        resp_user = json.loads(resp.data)
 
         expected_result = EXPECTED_RESULTS['post_new_user__success']
-
-        assert resp_user == expected_result
+        assert validate_response(resp.data, expected_result)
 
         assert User.select().count() == 1
         assert User.get().admin is False
@@ -104,7 +103,7 @@ class TestUser(TestCase):
         # email
         assert resp.status_code == BAD_REQUEST
         expected_result = EXPECTED_RESULTS['post_new_user_no_email__fail']
-        assert json.loads(resp.data) == expected_result
+        assert validate_response(resp.data, expected_result)
 
         assert User.select().count() == 0
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -10,7 +10,7 @@ from models import Address, Item, Order, User
 from tests.test_case import TestCase
 from tests.test_utils import (RESULTS, add_address, add_admin_user, add_user,
                               format_jsonapi_request, open_with_auth,
-                              validate_response, wrong_dump)
+                              assert_valid_response, wrong_dump)
 
 # main endpoint for API
 API_ENDPOINT = '/{}'
@@ -37,7 +37,7 @@ class TestUser(TestCase):
 
         assert resp.status_code == OK
         expected_result = EXPECTED_RESULTS['get_users_list__success']
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
     def test_post_new_user__success(self):
         user = format_jsonapi_request('user', {
@@ -53,7 +53,7 @@ class TestUser(TestCase):
         assert resp.status_code == CREATED
 
         expected_result = EXPECTED_RESULTS['post_new_user__success']
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
         assert User.select().count() == 1
         assert User.get().admin is False
@@ -103,7 +103,7 @@ class TestUser(TestCase):
         # email
         assert resp.status_code == BAD_REQUEST
         expected_result = EXPECTED_RESULTS['post_new_user_no_email__fail']
-        assert validate_response(resp.data, expected_result)
+        assert_valid_response(resp.data, expected_result)
 
         assert User.select().count() == 0
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -246,18 +246,16 @@ def assert_valid_response(data, expected):
         # data has already been parsed
         pass
 
-    # ensure that both `data` and `expected` are lists
-    if not isinstance(data, list):
-        data = [data]
-    if not isinstance(expected, list):
-        expected = [expected]
+    # ensure that both `data` and `expected` are lists while working on them
+    data_ = data if isinstance(data, list) else [data]
+    expected_ = expected if isinstance(expected, list) else [expected]
 
-    for item in data:
+    for item in data_:
         # Sort the included and errors lists of the response.data if present
         sort_data_lists(item, 'included', included_sorter)
         sort_data_lists(item, 'errors', errors_sorter)
 
-    for item in expected:
+    for item in expected_:
         # Sort the lists of the expected results if present
         sort_data_lists(item, 'included', included_sorter)
         sort_data_lists(item, 'errors', errors_sorter)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,8 +51,6 @@ class MockModelCreate:
     def __call__(self, created_at=mock_datetime(), uuid=None, **query):
         query['created_at'] = created_at
         query['uuid'] = uuid or next(self.uuid_generator)
-        # import pdb
-        # pdb.set_trace()
         return self.original(**query)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -221,9 +221,8 @@ def format_jsonapi_request(type_, data):
 def assert_valid_response(data, expected):
     """
     Take a flask app response.data and the expected test result, normalize them
-    sorting the `included` and `errors` lists if present, then confront, the
-    response data and the expected result, returning True or False wether the
-    structures are the same or not.
+    sorting the `included` and `errors` lists if present, then assert their
+    equality
     """
     def sort_data_lists(data, attribute, key):
         """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -247,15 +247,15 @@ def assert_valid_response(data, expected):
         pass
 
     # ensure that both `data` and `expected` are lists while working on them
-    data_ = data if isinstance(data, list) else [data]
-    expected_ = expected if isinstance(expected, list) else [expected]
+    data_items = data if isinstance(data, list) else [data]
+    expected_items = expected if isinstance(expected, list) else [expected]
 
-    for item in data_:
+    for item in data_items:
         # Sort the included and errors lists of the response.data if present
         sort_data_lists(item, 'included', included_sorter)
         sort_data_lists(item, 'errors', errors_sorter)
 
-    for item in expected_:
+    for item in expected_items:
         # Sort the lists of the expected results if present
         sort_data_lists(item, 'included', included_sorter)
         sort_data_lists(item, 'errors', errors_sorter)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -230,7 +230,7 @@ def assert_valid_response(data, expected):
         """
         try:
             data[attribute] = sorted(data[attribute], key=key)
-        except (KeyError, TypeError):
+        except KeyError:
             pass
 
     # sort functions for included and errors attributes


### PR DESCRIPTION
The function to automatically sort and normalize lists inside expected results and jsonapi response.

This is needed because marshmallow-jsonapi picks attributes at random when generating `included` or `errors` lists, so we can't rely on their position when asserting equality. this function returns sorts the lists if needed, confronts the two data structures and returns `True` or `False` based on their equality